### PR TITLE
27 enhance playerslice

### DIFF
--- a/src/store/playerSlice.js
+++ b/src/store/playerSlice.js
@@ -100,20 +100,20 @@ export const createPlayerSlice = (set, get) => ({
     set((state) => {
       const inventory = state.inventory.items;
       const equippedItems = state.player.equipped;
-  
+
       if (!inventory[itemId] || inventory[itemId] <= 0) {
         console.warn(`Item ${itemId} is not available in the inventory.`);
         return state;
       }
-  
+
       const updatedInventory = { ...inventory };
-      
+
       if (updatedInventory[itemId] > 1) {
         updatedInventory[itemId] -= 1;
       } else {
         delete updatedInventory[itemId];
       }
-  
+
       return {
         player: {
           ...state.player,
@@ -129,18 +129,18 @@ export const createPlayerSlice = (set, get) => ({
       };
     });
   },
-  
+
 
   unequipItem: (slot) => {
     set((state) => {
       const equippedItems = state.player.equipped;
       const itemId = equippedItems[slot];
-  
+
       if (!itemId) {
         console.warn(`No item equipped in ${slot}.`);
         return state;
       }
-  
+
       const updatedInventory = { ...state.inventory.items };
 
       if (updatedInventory[itemId]) {
@@ -148,7 +148,7 @@ export const createPlayerSlice = (set, get) => ({
       } else {
         updatedInventory[itemId] = 1;
       }
-  
+
       return {
         player: {
           ...state.player,
@@ -172,16 +172,16 @@ export const createPlayerSlice = (set, get) => ({
       let newXpToNextLvl = state.player.xpToNextLvl;
       let newMaxHp = state.player.maxHp;
       let currentHp = state.player.currentHp;
-  
+
       while (newXP >= newXpToNextLvl) {
-        newXP -= newXpToNextLvl; 
+        newXP -= newXpToNextLvl;
         newLevel += 1;
         newXpToNextLvl = Math.floor(newXpToNextLvl * 1.2); //XP scaling
-  
+
         newMaxHp = Math.floor(newMaxHp * 1.1); //HP scaling
-        currentHp = newMaxHp; 
+        currentHp = newMaxHp;
       }
-  
+
       return {
         player: {
           ...state.player,
@@ -194,5 +194,23 @@ export const createPlayerSlice = (set, get) => ({
       };
     });
   },
-  
+
+  heal: (amount) => {
+    set((state) => ({
+      player: {
+        ...state.player,
+        currentHp: Math.min(state.player.currentHp + amount, state.player.maxHp),
+      },
+    }));
+  },
+
+  takeDamage: (amount) => {
+    set((state) => ({
+      player: {
+        ...state.player,
+        currentHp: Math.max(0, state.player.currentHp - amount),
+      },
+    }));
+  },
+
 });


### PR DESCRIPTION
@BerkenA Her er noen metoder du kan bruke i battle
1. Lagt til setXP for levelup.
Den øker lvl, xp requirement for neste lvl og øker maxHp.
XP overflower til neste lvl om det blir xp til overs etter levelup.
Og spiller blir healet 100% på levelup.
Kan brukes sånn her:

```
const gainXP = (xp) => {
    const setXP = useGameStore((state) => state.setXP);
    setXP(xp);
};

gainXP(250);
```

3. Lagt til heal, og takeDamage metoder,
Kan for eksempel brukes sånn her:

```
const damagePlayer = (amount) => {
  const takeDamage = useGameStore((state) => state.takeDamage);
  takeDamage(amount);
};

damagePlayer(15);
```